### PR TITLE
Bug fix. Image thumbnail cannot be used to scale up.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,8 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- PIL thumbnail does not work for magnifying images (when scaling up).
+  Use resize instead. [sureshvv]
 
 
 1.3.4 (2014-09-07)

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -115,7 +115,10 @@ def scalePILImage(image, width=None, height=None, direction="down"):
     if scale_height == scale_width or direction == "thumbnail":
         # The original already has the right aspect ratio, so we only need
         # to scale.
-        image.thumbnail((width, height), PIL.Image.ANTIALIAS)
+        if direction == "down":
+            image.thumbnail((width, height), PIL.Image.ANTIALIAS)
+        else:
+            image = image.resize((width, height), PIL.Image.ANTIALIAS)
     else:
         if direction == "down":
             if scale_height is None or (

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -115,7 +115,7 @@ def scalePILImage(image, width=None, height=None, direction="down"):
     if scale_height == scale_width or direction == "thumbnail":
         # The original already has the right aspect ratio, so we only need
         # to scale.
-        if direction == "down":
+        if direction in ("down", "thumbnail"):
             image.thumbnail((width, height), PIL.Image.ANTIALIAS)
         else:
             image = image.resize((width, height), PIL.Image.ANTIALIAS)

--- a/plone/scale/tests/test_scale.py
+++ b/plone/scale/tests/test_scale.py
@@ -53,6 +53,9 @@ class ScalingTests(TestCase):
     def testSameSizeUpScale(self):
         self.assertEqual(scaleImage(PNG, 84, 103, "up")[2], (84, 103))
 
+    def testDoubleSizeUpScale(self):
+        self.assertEqual(scaleImage(PNG, 168, 206, "up")[2], (168, 206))
+
     def testHalfSizeUpScale(self):
         self.assertEqual(scaleImage(PNG, 42, 51, "up")[2], (42, 51))
 


### PR DESCRIPTION
When scaling up, use resize instead.