### PR TITLE
Fixes Products.CMFPlone#1361

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix KeyError in storage.AnnotationStorage._cleanup when attempting
+  to delete the storage for the same key twice.
+  [fulv]
 
 
 1.4 (2015-12-07)

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -182,7 +182,7 @@ class AnnotationStorage(DictMixin):
             if isinstance(key, tuple):
                 del storage[key]
             # clear cache from scales older than one day
-            if (modified_time and
+            elif (modified_time and
                     value['modified'] < modified_time - KEEP_SCALE_MILLIS):
                 del storage[key]
 


### PR DESCRIPTION
I have hit a case where it tries to `del storage[key]` for the same key successively both on line 183 and 187.  This should never happen.

