### PR TITLE
less restrictive factory passing. assume priority for passed factories.

### DIFF
--- a/plone/scale/interfaces.py
+++ b/plone/scale/interfaces.py
@@ -23,6 +23,7 @@ class IImageScaleFactory(Interface):
         direction='thumbnail',
         height=None,
         width=None,
+        scale=None,
         **parameters
     ):
         """Interface defining an actual scaling operation.
@@ -40,6 +41,10 @@ class IImageScaleFactory(Interface):
 
         ``width`` and ``height``
             target size
+
+        ``scale``
+            name of the current scale, if there is one. Can be used to retrieve
+             additional information such as cropping boxes.
 
         ``**parameters``
             is a dict with optional additional expected keyword arguments

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -171,9 +171,13 @@ class AnnotationStorage(DictMixin):
         # BBB/Deprecation handling
         if factory is not None:
             if scaling_factory is not None:
-                raise ValueError(
+                warnings.warn(
+                    'Deprecated usage of factory in plone.scale. '
                     'Factory is passed to plone.scale but also an adapter '
-                    'was found. No way to decide which one to execute.'
+                    'was found. No way to really decide which one to execute.'
+                    'To be nice and with a look at backward compatibility the '
+                    'passed one is used.',
+                    DeprecationWarning
                 )
             else:
                 warnings.warn(
@@ -182,7 +186,7 @@ class AnnotationStorage(DictMixin):
                     'dropped with plone.scale 3.0',
                     DeprecationWarning
                 )
-                result = factory(**parameters)
+            result = factory(**parameters)
         elif scaling_factory is not None:
             # this is what we want, keep this after deprecaton phase
             result = scaling_factory(**parameters)


### PR DESCRIPTION
Raising a ValueError if both factroies are available brought in problems with backward-compatibility. Reduced to a warning. Now the passed factory has priority.