### PR TITLE
Image mode optimization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,10 @@ New:
 - Scaled GIFs are converted to RGBA PNG images instead of converting them to JPEG.
   [thet, jensens]
 
-- Convert palette-based with a gray palette to grayscale+alpha images.
+- Convert palette-based images with a gray palette to grayscale+alpha images.
+  [didrix]
+
+- Convert images with 256 colors or less to palette-based images.
   [didrix]
 
 Fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Choose an appropriate image mode in order to reduce file size.
+  [didrix]
 
 Bug fixes:
 
@@ -29,12 +30,6 @@ New:
 
 - Scaled GIFs are converted to RGBA PNG images instead of converting them to JPEG.
   [thet, jensens]
-
-- Convert palette-based images with a gray palette to grayscale+alpha images.
-  [didrix]
-
-- Convert images with 256 colors or less to palette-based images.
-  [didrix]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ New:
 - Scaled GIFs are converted to RGBA PNG images instead of converting them to JPEG.
   [thet, jensens]
 
+- Convert palette-based with a gray palette to grayscale+alpha images.
+  [didrix]
+
 Fixes:
 
 - Don't scale images up for direction "down".

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -141,13 +141,13 @@ def scalePILImage(image, width=None, height=None, direction='down'):
         # Convert black&white to grayscale
         image = image.convert("L")
     elif image.mode == "P":
-        # If palette is grayscale, convert to gray+alpha
-        # Else convert palette based images to 3x8bit+alpha
         palette = image.getpalette()
+        # Convert palette based images to 3x8bit+alpha
+        image = image.convert("RGBA")
+        # If palette is grayscale, convert to gray+alpha
+        # needs to be RGBA first, because of bug in PIL
         if palette[0::3] == palette[1::3] == palette[2::3]:
             image = image.convert("LA")
-        else:
-            image = image.convert("RGBA")
     elif image.mode == "CMYK":
         # Convert CMYK to RGB, allowing for web previews of print images
         image = image.convert("RGB")

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -141,8 +141,13 @@ def scalePILImage(image, width=None, height=None, direction='down'):
         # Convert black&white to grayscale
         image = image.convert("L")
     elif image.mode == "P":
-        # Convert palette based images to 3x8bit+alpha
-        image = image.convert("RGBA")
+        # If palette is grayscale, convert to gray+alpha
+        # Else convert palette based images to 3x8bit+alpha
+        palette = image.getpalette()
+        if palette[0::3] == palette[1::3] == palette[2::3]:
+            image = image.convert("LA")
+        else:
+            image = image.convert("RGBA")
     elif image.mode == "CMYK":
         # Convert CMYK to RGB, allowing for web previews of print images
         image = image.convert("RGB")

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -145,13 +145,13 @@ def scalePILImage(image, width=None, height=None, direction='down'):
         # Convert black&white to grayscale
         image = image.convert("L")
     elif image.mode == "P":
-        palette = image.getpalette()
-        # Convert palette based images to 3x8bit+alpha
-        image = image.convert("RGBA")
         # If palette is grayscale, convert to gray+alpha
-        # needs to be RGBA first, because of bug in PIL
+        # Else convert palette based images to 3x8bit+alpha
+        palette = image.getpalette()
         if palette[0::3] == palette[1::3] == palette[2::3]:
             image = image.convert("LA")
+        else:
+            image = image.convert("RGBA")
     elif image.mode == "CMYK":
         # Convert CMYK to RGB, allowing for web previews of print images
         image = image.convert("RGB")

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -50,6 +50,10 @@ def scaleImage(image, width=None, height=None, direction='down',
 
     image = scalePILImage(image, width, height, direction)
 
+    # convert to palette if possible
+    if format_ == 'PNG' and image.getcolors(maxcolors=256):
+        image = image.convert('P')
+
     new_result = False
 
     if result is None:

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -50,9 +50,12 @@ def scaleImage(image, width=None, height=None, direction='down',
 
     image = scalePILImage(image, width, height, direction)
 
-    # convert to palette if possible
-    if format_ == 'PNG' and image.getcolors(maxcolors=256):
-        image = image.convert('P')
+    # convert to simpler mode if possible
+    if image.mode not in ('P', 'L') and image.getcolors(maxcolors=256):
+        if format_ == 'JPEG':
+            image = image.convert('L')
+        elif format_ == 'PNG':
+            image = image.convert('P')
 
     new_result = False
 


### PR DESCRIPTION
Try and pick a better image mode when possible:

* when converting a P-mode image, check if it's grayscale and convert to LA if so, which is about half the file size. Else convert to RGBA like previously.
* if we have an image that (after scaling) has 256 colors or fewer, convert is to p-mode. This can result in a file size reduction up to about 75%.