### PR TITLE
Set zip_safe=False in setup.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ New:
 
 Fixes:
 
-- *add item here*
+- Set ``zip_safe=False`` in ``setup.py``.  Otherwise you cannot run
+  the tests of the released package because the test runner does not
+  find any tests in the egg file.  Note that this is only a problem in
+  zc.buildout 1.x: it uses unzip=False by default.  zc.buildout 2.x no
+  longer has this option and always unzips eggs.  [maurits]
 
 
 1.4.1 (2016-02-12)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     packages=find_packages(exclude=["ez_setup"]),
     namespace_packages=["plone"],
     include_package_data=True,
-    zip_safe=True,
+    zip_safe=False,
     test_suite="plone.scale",
     install_requires=[
         # We can't actually depend on PIL because not everyone can install it


### PR DESCRIPTION
Otherwise you cannot run the tests of the released package because the test runner does not find any tests in the egg file.

Note that this is only a problem in zc.buildout 1.x: it uses unzip=False by default.  zc.buildout 2.x no longer has this option and always unzips eggs.

Looks like we have not been running the plone.scale tests on Jenkins for Plone 4.3 and 5.0 because of this... I don't see errors locally, so should be okay.

Note that this is the only plone package that has this setting.