### PR TITLE
Catch KeyError when deleting non existing scale. [1.4]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ New:
 
 Fixes:
 
+- Catch KeyError when deleting non existing scale.  This can happen in corner cases.
+  Fixes `issue 15 <https://github.com/plone/plone.scale/issues/15>`_.
+  [maurits]
+
 - Set ``zip_safe=False`` in ``setup.py``.  Otherwise you cannot run
   the tests of the released package because the test runner does not
   find any tests in the egg file.  Note that this is only a problem in

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -155,7 +155,7 @@ class AnnotationStorage(DictMixin):
         storage = self.storage
         info = self.get_info_by_hash(key)
         if info is not None and self._modified_since(info['modified']):
-            del storage[info['uid']]
+            del self[info['uid']]
             # invalidate when the image was updated
             info = None
         if info is None and factory:
@@ -180,11 +180,11 @@ class AnnotationStorage(DictMixin):
             # remove info stored by tuple keys
             # before refactoring
             if isinstance(key, tuple):
-                del storage[key]
+                del self[key]
             # clear cache from scales older than one day
             elif (modified_time and
                     value['modified'] < modified_time - KEEP_SCALE_MILLIS):
-                del storage[key]
+                del self[key]
 
     def __getitem__(self, uid):
         return self.storage[uid]
@@ -193,7 +193,12 @@ class AnnotationStorage(DictMixin):
         raise RuntimeError('New scales have to be created via scale()')
 
     def __delitem__(self, uid):
-        del self.storage[uid]
+        try:
+            del self.storage[uid]
+        except KeyError:
+            # This should not happen, but it apparently can happen in corner
+            # cases.  See https://github.com/plone/plone.scale/issues/15
+            logger.warn('Could not delete key %s from storage.', uid)
 
     def __iter__(self):
         return iter(self.storage)

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -94,7 +94,10 @@ class AnnotationStorageTests(TestCase):
 
     def testDeleteNonExistingItem(self):
         storage = self.storage
-        self.assertRaises(KeyError, delitem, storage, 'foo')
+        # This used to raise a KeyError, but sometimes the underlying storage
+        # can get inconsistent, so it is nicer to accept it.
+        # See https://github.com/plone/plone.scale/issues/15
+        delitem(storage, 'foo')
 
     def testDeleteRemovesItemAndIndex(self):
         storage = self.storage


### PR DESCRIPTION
This can happen in corner cases.

Fixes https://github.com/plone/plone.scale/issues/15