### PR TITLE
Various scale storage bug fixes [1.4.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New:
 
 Fixes:
 
+- When getting an outdated scale, don't throw it away when there is no
+  factory.  [maurits]
+
 - Avoid TypeErrors when looking for outdated scales.
   Fixes `issue 12 <https://github.com/plone/plone.scale/issues/12>`_.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ New:
 
 Fixes:
 
+- Avoid TypeErrors when looking for outdated scales.
+  Fixes `issue 12 <https://github.com/plone/plone.scale/issues/12>`_.
+  [maurits]
+
 - Catch KeyError when deleting non existing scale.  This can happen in corner cases.
   Fixes `issue 15 <https://github.com/plone/plone.scale/issues/15>`_.
   [maurits]

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -162,7 +162,8 @@ class AnnotationStorage(DictMixin):
         key = self.hash(**parameters)
         storage = self.storage
         info = self.get_info_by_hash(key)
-        if info is not None and self._modified_since(info['modified']):
+        if (info is not None and factory and
+                self._modified_since(info['modified'])):
             del self[info['uid']]
             # invalidate when the image was updated
             info = None

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -13,6 +13,8 @@ logger = logging.getLogger('plone.scale')
 # This is one day:
 KEEP_SCALE_MILLIS = 24 * 60 * 60 * 1000
 
+number_types = (float, int, long)
+
 
 class IImageScaleStorage(Interface):
     """ This is an adapter for image content which can store, retrieve and
@@ -113,12 +115,12 @@ class AnnotationStorage(DictMixin):
         modified_time = self.modified_time
         if modified_time is None:
             return False
-        # We expect either a float or an int, but in corner cases it can be
+        # We expect a number, but in corner cases it can be
         # something else entirely.
         # https://github.com/plone/plone.scale/issues/12
-        if not isinstance(modified_time, (float, int)):
+        if not isinstance(modified_time, number_types):
             return False
-        if not isinstance(since, (float, int)):
+        if not isinstance(since, number_types):
             return False
         since = since - offset
         return modified_time > since
@@ -187,7 +189,7 @@ class AnnotationStorage(DictMixin):
         modified_time = self.modified_time
         if modified_time is None:
             return
-        if not isinstance(modified_time, (float, int)):
+        if not isinstance(modified_time, number_types):
             # https://github.com/plone/plone.scale/issues/12
             return
         for key, value in storage.items():

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -110,6 +110,9 @@ class AnnotationStorage(DictMixin):
         self.modified = modified
 
     def _modified_since(self, since, offset=0):
+        # offset gets subtracted from the main modified time: this allows to
+        # keep scales for a bit longer if needed, even when the main image has
+        # changed.
         if since is None:
             return False
         modified_time = self.modified_time
@@ -122,7 +125,7 @@ class AnnotationStorage(DictMixin):
             return False
         if not isinstance(since, number_types):
             return False
-        since = since - offset
+        modified_time = modified_time - offset
         return modified_time > since
 
     @property


### PR DESCRIPTION
This fixes issues #12. (No longer issue #18, because that turns out not to be an issue).

Plus it fixes an extra problem that I have not yet seen, but that might happen. When getting a scale, we throw it away when it is outdated: it will be replaced by a new scale in the same method.  Problem: when there is no factory, the new scale will not be generated and we have just lost the old scale, which may be outdated, but better than nothing.