### PR TITLE
Catch KeyError when deleting non existing scale. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ New features:
 
 Bug fixes:
 
+- Catch KeyError when deleting non existing scale.  This can happen in corner cases.
+  Fixes `issue 15 <https://github.com/plone/plone.scale/issues/15>`_.
+  [maurits]
+
 - Set ``zip_safe=False`` in ``setup.py``.  Otherwise you cannot run
   the tests of the released package because the test runner does not
   find any tests in the egg file.  Note that this is only a problem in

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -171,7 +171,10 @@ class AnnotationStorageTests(TestCase):
 
     def testDeleteNonExistingItem(self):
         storage = self.storage
-        self.assertRaises(KeyError, delitem, storage, 'foo')
+        # This used to raise a KeyError, but sometimes the underlying storage
+        # can get inconsistent, so it is nicer to accept it.
+        # See https://github.com/plone/plone.scale/issues/15
+        delitem(storage, 'foo')
 
     def testDeleteRemovesItemAndIndexBBB(self):
         storage = self.storage


### PR DESCRIPTION
This can happen in corner cases.

Fixes https://github.com/plone/plone.scale/issues/15
Same as pull request #17, but now for master.