### PR TITLE
Remove Persistence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove unused dependency.
+  [gforcada]
 
 
 2.1.1 (2017-03-29)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ STORAGE_REQUIREMENTS = [
     'zope.component',
     'zope.configuration',
     'zope.interface',
-    'Persistence',
 ]
 
 TESTS_REQUIREMENTS = [


### PR DESCRIPTION
It seems not to be used anywhere...

@witsch you added this dependency back in 2010: https://github.com/plone/plone.scale/commit/0171cdec635b3f1f0a5b076386ba17bd9aba157c what was the purpose?