### PR TITLE
Only convert JPEG to greyscale if they actually are and not when the image has less than 256 colors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ New features:
 
 Bug fixes:
 
+- Only convert JPEG to greyscale if they actually are and not when the image
+  has less than 256 colors. This bug was introduced in 2.1 with PR #13.
+  [fschulze]
+
 - Preserve color profile in scaled images.
   [fschulze]
 

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -52,9 +52,12 @@ def scaleImage(image, width=None, height=None, direction='down',
     image = scalePILImage(image, width, height, direction)
 
     # convert to simpler mode if possible
-    if image.mode not in ('P', 'L') and image.getcolors(maxcolors=256):
+    colors = image.getcolors(maxcolors=256)
+    if image.mode not in ('P', 'L') and colors:
         if format_ == 'JPEG':
-            image = image.convert('L')
+            # check if it's all grey
+            if all(rgb[0] == rgb[1] == rgb[2] for c, rgb in colors):
+                image = image.convert('L')
         elif format_ == 'PNG':
             image = image.convert('P')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.1.1.dev0'
+version = '2.1.1.dev1'
 readme = open('README.rst').read().replace(':class:', '').replace(':mod:', '')
 changes = open('CHANGES.rst').read()
 


### PR DESCRIPTION
This bug was introduced in 2.1 with PR #13.