### PR TITLE
Restore scale down behaviour from 1.x series without the huge memory usage.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,13 @@ Changelog
 =========
 
 
-2.2.1 (unreleased)
-------------------
+3.0 (unreleased)
+----------------
 
 Breaking changes:
 
-- *add item here*
+- Restore scale down behaviour from 1.x series without the huge memory usage.
+  [fschulze]
 
 New features:
 

--- a/plone/scale/tests/test_scale.py
+++ b/plone/scale/tests/test_scale.py
@@ -102,7 +102,27 @@ class ScalingTests(TestCase):
         self.assertEqual(scaleImage(PNG, 20, 51, "down")[2], (20, 51))
 
     def testNoStretchingDownScale(self):
-        self.assertEqual(scaleImage(PNG, 200, 103, "down")[2], (84, 103))
+        self.assertEqual(scaleImage(PNG, 200, 103, "down")[2], (200, 103))
+
+    def testHugeScale(self):
+        # the image will be cropped, but not scaled
+        self.assertEqual(scaleImage(PNG, 400, 99999, "down")[2], (2, 103))
+
+    def testCropPreWideScaleUnspecifiedHeight(self):
+        image = scaleImage(PNG, 400, None, "down")
+        self.assertEqual(image[2], (400, 490))
+
+    def testCropPreWideScale(self):
+        image = scaleImage(PNG, 400, 100, "down")
+        self.assertEqual(image[2], (400, 100))
+
+    def testCropPreTallScaleUnspecifiedWidth(self):
+        image = scaleImage(PNG, None, 400, "down")
+        self.assertEqual(image[2], (326, 400))
+
+    def testCropPreTallScale(self):
+        image = scaleImage(PNG, 100, 400, "down")
+        self.assertEqual(image[2], (100, 400))
 
     def testRestrictWidthOnlyDownScaleNone(self):
         self.assertEqual(scaleImage(PNG, 42, None, "down")[2], (42, 52))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.2.1.dev0'
+version = '3.0.dev0'
 readme = open('README.rst').read().replace(':class:', '').replace(':mod:', '')
 changes = open('CHANGES.rst').read()
 


### PR DESCRIPTION
Commit a789cfb5d1efbd8e38f460a08eef36a0c0ba9a5f changed the scaling behaviour. The documentation for scaling ``up`` and ``down`` doesn't match anymore because of this. Quite a few use cases, like banners with fixed with and height which just crop any overflow, broke due to that change. This PR crops the source image before scaling and crops the remainder after scaling, resulting in the same output as 1.x but without the extensive memory use described in the commit.

The following are the image size differences between 1.x and 2.x:
```diff
--- 1.x.txt	2017-08-18 09:43:33.000000000 +0200
+++ 2.x.txt	2017-08-18 09:43:39.000000000 +0200
@@ -6,37 +6,37 @@
 big-square-up-x400.jpeg (400, 400)
 big-square-up-400x400.jpeg (400, 400)
 big-tall.jpg
-big-tall-down-400x.jpeg (400, 4000)
+big-tall-down-400x.jpeg (100, 1000)
 big-tall-down-x400.jpeg (40, 400)
-big-tall-down-400x400.jpeg (400, 400)
+big-tall-down-400x400.jpeg (100, 1000)
 big-tall-up-400x.jpeg (400, 4000)
 big-tall-up-x400.jpeg (40, 400)
 big-tall-up-400x400.jpeg (40, 400)
 big-wide.jpg
 big-wide-down-400x.jpeg (400, 40)
-big-wide-down-x400.jpeg (4000, 400)
-big-wide-down-400x400.jpeg (400, 400)
+big-wide-down-x400.jpeg (1000, 100)
+big-wide-down-400x400.jpeg (1000, 100)
 big-wide-up-400x.jpeg (400, 40)
 big-wide-up-x400.jpeg (4000, 400)
 big-wide-up-400x400.jpeg (400, 40)
 small-square.jpg
-small-square-down-400x.jpeg (400, 400)
-small-square-down-x400.jpeg (400, 400)
+small-square-down-400x.jpeg (100, 100)
+small-square-down-x400.jpeg (100, 100)
 small-square-down-400x400.jpeg (100, 100)
 small-square-up-400x.jpeg (400, 400)
 small-square-up-x400.jpeg (400, 400)
 small-square-up-400x400.jpeg (400, 400)
 small-tall.jpg
-small-tall-down-400x.jpeg (400, 4000)
-small-tall-down-x400.jpeg (40, 400)
-small-tall-down-400x400.jpeg (400, 400)
+small-tall-down-400x.jpeg (10, 100)
+small-tall-down-x400.jpeg (10, 100)
+small-tall-down-400x400.jpeg (10, 100)
 small-tall-up-400x.jpeg (400, 4000)
 small-tall-up-x400.jpeg (40, 400)
 small-tall-up-400x400.jpeg (40, 400)
 small-wide.jpg
-small-wide-down-400x.jpeg (400, 40)
-small-wide-down-x400.jpeg (4000, 400)
-small-wide-down-400x400.jpeg (400, 400)
+small-wide-down-400x.jpeg (100, 10)
+small-wide-down-x400.jpeg (100, 10)
+small-wide-down-400x400.jpeg (100, 10)
 small-wide-up-400x.jpeg (400, 40)
 small-wide-up-x400.jpeg (4000, 400)
 small-wide-up-400x400.jpeg (400, 40)
```

Additionally I added a limit of 64 megapixels for the resulting image, which would mean a roughly 256 MB memory use for the raw image. (This should be enough for everyone)