### PR TITLE
New ``mode`` argument replacing ``direction``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ New features:
 
 - *add item here*
 
+Changes:
+
+- The ``mode`` argument replaces the old, now deprecated, ``direction``
+  argument. The new names are ``contain`` or ``scale-crop-to-fit`` instead of
+  ``down``, ``cover`` or ``scale-crop-to-fill`` instead of ``up`` and
+  ``scale`` instead of ``thumbnail``.
+
 Bug fixes:
 
 - Fix cleanup of image scales in py3

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -188,6 +188,11 @@ def scalePILImage(image, width=None, height=None, mode='contain', direction=None
             "the 'thumbnail' scaling mode is deprecated, use 'scale' instead",
             DeprecationWarning)
         mode = "scale"
+    if mode == "keep":
+        warnings.warn(
+            "the 'keep' scaling mode is deprecated, use 'scale' instead",
+            DeprecationWarning)
+        mode = "scale"
     if mode == "scale-crop-to-fit":
         mode = "contain"
     if mode == "scale-crop-to-fill":

--- a/plone/scale/tests/test_scale.py
+++ b/plone/scale/tests/test_scale.py
@@ -250,7 +250,4 @@ class ScalingTests(TestCase):
 
 def test_suite():
     from unittest import defaultTestLoader
-    from warnings import filterwarnings
-    filterwarnings("error", "the 'direction' option is deprecated")
-    filterwarnings("error", "the '.*' scaling mode is deprecated")
     return defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/scale/tests/test_scale.py
+++ b/plone/scale/tests/test_scale.py
@@ -236,7 +236,7 @@ class ScalingTests(TestCase):
                 str(w[0].message))
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            scaleImage(PNG, 16, 16, direction="up")
+            scaleImage(PNG, 16, 16, direction="keep")
             self.assertEqual(len(w), 2)
             self.assertIs(w[0].category, DeprecationWarning)
             self.assertIn(
@@ -244,7 +244,7 @@ class ScalingTests(TestCase):
                 str(w[0].message))
             self.assertIs(w[1].category, DeprecationWarning)
             self.assertIn(
-                "the 'up' scaling mode is deprecated",
+                "the 'keep' scaling mode is deprecated",
                 str(w[1].message))
 
 

--- a/plone/scale/tests/test_scale.py
+++ b/plone/scale/tests/test_scale.py
@@ -9,6 +9,7 @@ from plone.scale.tests import TEST_DATA_LOCATION
 from unittest import TestCase
 
 import os.path
+import warnings
 import PIL.Image, PIL.ImageDraw
 
 
@@ -22,19 +23,19 @@ PROFILE = open(os.path.join(TEST_DATA_LOCATION, "profile.jpg"), 'rb').read()
 class ScalingTests(TestCase):
 
     def testNewSizeReturned(self):
-        (imagedata, format, size) = scaleImage(PNG, 42, 51, "down")
+        (imagedata, format, size) = scaleImage(PNG, 42, 51, "contain")
         input = StringIO(imagedata)
         image = PIL.Image.open(input)
         self.assertEqual(image.size, size)
 
     def testScaledImageKeepPNG(self):
-        self.assertEqual(scaleImage(PNG, 84, 103, "down")[1], "PNG")
+        self.assertEqual(scaleImage(PNG, 84, 103, "contain")[1], "PNG")
 
     def testScaledImageKeepGIFto(self):
-        self.assertEqual(scaleImage(GIF, 84, 103, "down")[1], "PNG")
+        self.assertEqual(scaleImage(GIF, 84, 103, "contain")[1], "PNG")
 
     def testScaledImageIsJpeg(self):
-        self.assertEqual(scaleImage(TIFF, 84, 103, "down")[1], "JPEG")
+        self.assertEqual(scaleImage(TIFF, 84, 103, "contain")[1], "JPEG")
 
     def testAlphaForcesPNG(self):
         # first image without alpha
@@ -44,7 +45,7 @@ class ScalingTests(TestCase):
                 src.putpixel((x, y), (x, y, 0, 255))
         result = StringIO()
         src.save(result, "TIFF")
-        self.assertEqual(scaleImage(result, 84, 103, "down")[1], "JPEG")
+        self.assertEqual(scaleImage(result, 84, 103, "contain")[1], "JPEG")
         # now with alpha
         src = PIL.Image.new("RGBA", (256, 256), (255, 255, 255, 128))
         result = StringIO()
@@ -52,25 +53,25 @@ class ScalingTests(TestCase):
             for x in range(0, 256):
                 src.putpixel((x, y), (x, y, 0, x))
         src.save(result, "TIFF")
-        self.assertEqual(scaleImage(result, 84, 103, "down")[1], "PNG")
+        self.assertEqual(scaleImage(result, 84, 103, "contain")[1], "PNG")
 
     def testScaledCMYKIsRGB(self):
-        (imagedata, format, size) = scaleImage(CMYK, 42, 51, "down")
+        (imagedata, format, size) = scaleImage(CMYK, 42, 51, "contain")
         input = StringIO(imagedata)
         image = PIL.Image.open(input)
         self.assertEqual(image.mode, "RGB")
 
     def testScaledPngImageIsPng(self):
-        self.assertEqual(scaleImage(PNG, 84, 103, "down")[1], "PNG")
+        self.assertEqual(scaleImage(PNG, 84, 103, "contain")[1], "PNG")
 
     def testScaledPreservesProfile(self):
-        (imagedata, format, size) = scaleImage(PROFILE, 42, 51, "down")
+        (imagedata, format, size) = scaleImage(PROFILE, 42, 51, "contain")
         input = StringIO(imagedata)
         image = PIL.Image.open(input)
         self.assertIsNotNone(image.info.get('icc_profile'))
 
     def testScaleWithFewColorsStaysColored(self):
-        (imagedata, format, size) = scaleImage(PROFILE, 16, None, "down")
+        (imagedata, format, size) = scaleImage(PROFILE, 16, None, "contain")
         image = PIL.Image.open(StringIO(imagedata))
         self.assertEqual(max(image.size), 16)
         self.assertEqual(image.mode, 'RGB')
@@ -83,7 +84,7 @@ class ScalingTests(TestCase):
             draw.line(((0, i), (256, i)), fill=(i, i, i))
         result = StringIO()
         src.save(result, "JPEG")
-        (imagedata, format, size) = scaleImage(result, 200, None, "down")
+        (imagedata, format, size) = scaleImage(result, 200, None, "contain")
         image = PIL.Image.open(StringIO(imagedata))
         self.assertEqual(max(image.size), 200)
         self.assertEqual(image.mode, 'L')
@@ -104,79 +105,79 @@ class ScalingTests(TestCase):
         self.assertEqual(png.format, 'PNG')
         self.assertIsNone(png.getcolors(maxcolors=256))
         # scale it to a size where we get less than 256 colors
-        (imagedata, format, size) = scaleImage(dst.getvalue(), 24, None, "down")
+        (imagedata, format, size) = scaleImage(dst.getvalue(), 24, None, "contain")
         image = PIL.Image.open(StringIO(imagedata))
         # we should now have an image in palette mode
         self.assertEqual(image.mode, 'P')
         self.assertEqual(image.format, 'PNG')
 
     def testSameSizeDownScale(self):
-        self.assertEqual(scaleImage(PNG, 84, 103, "down")[2], (84, 103))
+        self.assertEqual(scaleImage(PNG, 84, 103, "contain")[2], (84, 103))
 
     def testHalfSizeDownScale(self):
-        self.assertEqual(scaleImage(PNG, 42, 51, "down")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, 42, 51, "contain")[2], (42, 51))
 
     def testScaleWithCropDownScale(self):
-        self.assertEqual(scaleImage(PNG, 20, 51, "down")[2], (20, 51))
+        self.assertEqual(scaleImage(PNG, 20, 51, "contain")[2], (20, 51))
 
     def testNoStretchingDownScale(self):
-        self.assertEqual(scaleImage(PNG, 200, 103, "down")[2], (200, 103))
+        self.assertEqual(scaleImage(PNG, 200, 103, "contain")[2], (200, 103))
 
     def testHugeScale(self):
         # the image will be cropped, but not scaled
-        self.assertEqual(scaleImage(PNG, 400, 99999, "down")[2], (2, 103))
+        self.assertEqual(scaleImage(PNG, 400, 99999, "contain")[2], (2, 103))
 
     def testCropPreWideScaleUnspecifiedHeight(self):
-        image = scaleImage(PNG, 400, None, "down")
+        image = scaleImage(PNG, 400, None, "contain")
         self.assertEqual(image[2], (400, 490))
 
     def testCropPreWideScale(self):
-        image = scaleImage(PNG, 400, 100, "down")
+        image = scaleImage(PNG, 400, 100, "contain")
         self.assertEqual(image[2], (400, 100))
 
     def testCropPreTallScaleUnspecifiedWidth(self):
-        image = scaleImage(PNG, None, 400, "down")
+        image = scaleImage(PNG, None, 400, "contain")
         self.assertEqual(image[2], (326, 400))
 
     def testCropPreTallScale(self):
-        image = scaleImage(PNG, 100, 400, "down")
+        image = scaleImage(PNG, 100, 400, "contain")
         self.assertEqual(image[2], (100, 400))
 
     def testRestrictWidthOnlyDownScaleNone(self):
-        self.assertEqual(scaleImage(PNG, 42, None, "down")[2], (42, 52))
+        self.assertEqual(scaleImage(PNG, 42, None, "contain")[2], (42, 52))
 
     def testRestrictWidthOnlyDownScaleZero(self):
-        self.assertEqual(scaleImage(PNG, 42, 0, "down")[2], (42, 52))
+        self.assertEqual(scaleImage(PNG, 42, 0, "contain")[2], (42, 52))
 
     def testRestrictHeightOnlyDownScaleNone(self):
-        self.assertEqual(scaleImage(PNG, None, 51, "down")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, None, 51, "contain")[2], (42, 51))
 
     def testRestrictHeightOnlyDownScaleZero(self):
-        self.assertEqual(scaleImage(PNG, 0, 51, "down")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, 0, 51, "contain")[2], (42, 51))
 
     def testSameSizeUpScale(self):
-        self.assertEqual(scaleImage(PNG, 84, 103, "up")[2], (84, 103))
+        self.assertEqual(scaleImage(PNG, 84, 103, "cover")[2], (84, 103))
 
     def testDoubleSizeUpScale(self):
-        self.assertEqual(scaleImage(PNG, 168, 206, "up")[2], (168, 206))
+        self.assertEqual(scaleImage(PNG, 168, 206, "cover")[2], (168, 206))
 
     def testHalfSizeUpScale(self):
-        self.assertEqual(scaleImage(PNG, 42, 51, "up")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, 42, 51, "cover")[2], (42, 51))
 
     def testNoStretchingUpScale(self):
-        self.assertEqual(scaleImage(PNG, 200, 103, "up")[2], (84, 103))
+        self.assertEqual(scaleImage(PNG, 200, 103, "cover")[2], (84, 103))
 
     def testRestrictWidthOnlyUpScaleNone(self):
-        self.assertEqual(scaleImage(PNG, 42, None, "up")[2], (42, 52))
+        self.assertEqual(scaleImage(PNG, 42, None, "cover")[2], (42, 52))
 
     def testRestrictWidthOnlyUpScaleZero(self):
-        self.assertEqual(scaleImage(PNG, 42, 0, "up")[2], (42, 52))
+        self.assertEqual(scaleImage(PNG, 42, 0, "cover")[2], (42, 52))
 
     def testRestrictHeightOnlyUpScaleNone(self):
-        self.assertEqual(scaleImage(PNG, None, 51, "up")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, None, 51, "cover")[2], (42, 51))
 
     def testRestrictHeightOnlyUpScaleZero(self):
-        self.assertEqual(scaleImage(PNG, 0, 51, "up")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, 0, 51, "cover")[2], (42, 51))
 
     def testNoRestrictionsNone(self):
         self.assertRaises(ValueError, scaleImage, PNG, None, None)
@@ -185,16 +186,13 @@ class ScalingTests(TestCase):
         self.assertRaises(ValueError, scaleImage, PNG, 0, 0)
 
     def testKeepAspectRatio(self):
-        self.assertEqual(scaleImage(PNG, 80, 80, "thumbnail")[2], (65, 80))
-
-    def testKeepAspectRatioBBB(self):
-        self.assertEqual(scaleImage(PNG, 80, 80, "keep")[2], (65, 80))
+        self.assertEqual(scaleImage(PNG, 80, 80, "scale")[2], (65, 80))
 
     def testThumbnailHeightNone(self):
-        self.assertEqual(scaleImage(PNG, 42, None, "thumbnail")[2], (42, 51))
+        self.assertEqual(scaleImage(PNG, 42, None, "scale")[2], (42, 51))
 
     def testThumbnailWidthNone(self):
-        self.assertEqual(scaleImage(PNG, None, 51, "thumbnail")[2], (41, 51))
+        self.assertEqual(scaleImage(PNG, None, 51, "scale")[2], (41, 51))
 
     def testQuality(self):
         img1 = scaleImage(CMYK, 84, 103)[0]
@@ -211,7 +209,48 @@ class ScalingTests(TestCase):
         self.assertEqual(result, img2)      # the return value _is_ the buffer
         self.assertEqual(result.getvalue(), img1)   # but with the same value
 
+    def testDeprecations(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scaleImage(PNG, 16, 16, "down")
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, DeprecationWarning)
+            self.assertIn(
+                "the 'down' scaling mode is deprecated",
+                str(w[0].message))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scaleImage(PNG, 16, 16, "up")
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, DeprecationWarning)
+            self.assertIn(
+                "the 'up' scaling mode is deprecated",
+                str(w[0].message))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scaleImage(PNG, 16, 16, "thumbnail")
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, DeprecationWarning)
+            self.assertIn(
+                "the 'thumbnail' scaling mode is deprecated",
+                str(w[0].message))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scaleImage(PNG, 16, 16, direction="up")
+            self.assertEqual(len(w), 2)
+            self.assertIs(w[0].category, DeprecationWarning)
+            self.assertIn(
+                "the 'direction' option is deprecated",
+                str(w[0].message))
+            self.assertIs(w[1].category, DeprecationWarning)
+            self.assertIn(
+                "the 'up' scaling mode is deprecated",
+                str(w[1].message))
+
 
 def test_suite():
     from unittest import defaultTestLoader
+    from warnings import filterwarnings
+    filterwarnings("error", "the 'direction' option is deprecated")
+    filterwarnings("error", "the '.*' scaling mode is deprecated")
     return defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -256,7 +256,4 @@ class AnnotationStorageTests(TestCase):
 
 def test_suite():
     from unittest import defaultTestLoader
-    from warnings import filterwarnings
-    filterwarnings("error", "the 'direction' option is deprecated")
-    filterwarnings("error", "the '.*' scaling mode is deprecated")
     return defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -256,4 +256,7 @@ class AnnotationStorageTests(TestCase):
 
 def test_suite():
     from unittest import defaultTestLoader
+    from warnings import filterwarnings
+    filterwarnings("error", "the 'direction' option is deprecated")
+    filterwarnings("error", "the '.*' scaling mode is deprecated")
     return defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
As suggested by @thet, this PR implements the new ``mode`` argument replacing the now deprecated ``direction`` argument. Both the names suggested by @thet and @davisagli are supported.