### PR TITLE
Fix conflict resolution code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix conflict resolution code corner case.
+  [gforcada]
 
 
 3.0 (2017-10-02)

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -77,14 +77,14 @@ class ScalesDict(PersistentDict):
             if key not in new:
                 deleted.append(key)
         for key in deleted:
-            if ((key in saved) and
-                    (old[key]['modified'] == saved[key]['modified'])):
-                # unchanged by saved, deleted by new
-                logger.debug('deleted %s' % repr(key))
-                del saved[key]
-            else:
-                # modified by saved, deleted by new
-                self.raise_conflict(saved[key], new[key])
+            if key in saved:
+                if old[key]['modified'] == saved[key]['modified']:
+                    # unchanged by saved, deleted by new
+                    logger.debug('deleted %s' % repr(key))
+                    del saved[key]
+                else:
+                    # modified by saved, deleted by new
+                    self.raise_conflict(saved[key], new[key])
         for key in added:
             if key in saved:
                 # added by saved, added by new


### PR DESCRIPTION
That's a bit long, so take a cup of your $BEVERAGE of choice :-)

In this scenario we have some KEYS that were deleted
(i.e. no longer in newState as they were in oldState).

Now, to compare it against savedState there are three possibilities:
- KEY is also removed in savedState: all good, no conflict as newState
  also deleted it
- KEY is still in savedState exactly as it was in oldState:
  remove it from savedState and we are all good
- the KEY is still in savedState BUT modified since oldState:
  that's a conflict

The code thus far handled correctly the second case but treated both
first and third case as a conflict.

But to make it worst the first case treated as a conflict meant that
rather than raising a ConflictError a KeyError was raised due to trying
to pretty print a non existing key from savedState.

There might be other cases where this is also happening,
thus far on our servers we are only being hit by this KeyError.

cc @gotcha 