### PR TITLE
Fixed DeprecationWarning with Pillow 9.1.0 for ANTIALIAS.

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,3 @@
+Fixed ``DeprecationWarning`` with Pillow 9.1.0 for ``ANTIALIAS``.
+Use ``Resampling.LANCZOS``, falling back to ``ANTIALIAS`` on older Pillows.
+[maurits]

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -7,6 +7,13 @@ import sys
 import warnings
 
 
+try:
+    # Pillow 9.1.0+
+    LANCZOS = PIL.Image.Resampling.LANCZOS
+except AttributeError:
+    LANCZOS = PIL.Image.ANTIALIAS
+
+
 def none_as_int(the_int):
     """For python 3 compatibility, to make int vs. none comparison possible
     without changing the algorithms below.
@@ -131,7 +138,7 @@ def _scale_thumbnail(image, width=None, height=None):
 
     image.draft(image.mode, (dimensions.target_width, dimensions.target_height))
     image = image.resize(
-        (dimensions.target_width, dimensions.target_height), PIL.Image.ANTIALIAS
+        (dimensions.target_width, dimensions.target_height), LANCZOS
     )
     return image
 
@@ -393,11 +400,11 @@ def scalePILImage(image, width=None, height=None, mode="contain", direction=None
         # to scale.
         if mode == "contain":
             image.thumbnail(
-                (dimensions.final_width, dimensions.final_height), PIL.Image.ANTIALIAS
+                (dimensions.final_width, dimensions.final_height), LANCZOS
             )
             return image
         return image.resize(
-            (dimensions.final_width, dimensions.final_height), PIL.Image.ANTIALIAS
+            (dimensions.final_width, dimensions.final_height), LANCZOS
         )
 
     if dimensions.pre_scale_crop:
@@ -412,7 +419,7 @@ def scalePILImage(image, width=None, height=None, mode="contain", direction=None
 
     image.draft(image.mode, (dimensions.target_width, dimensions.target_height))
     image = image.resize(
-        (dimensions.target_width, dimensions.target_height), PIL.Image.ANTIALIAS
+        (dimensions.target_width, dimensions.target_height), LANCZOS
     )
 
     if dimensions.post_scale_crop:


### PR DESCRIPTION
Use `Resampling.LANCZOS`, falling back to `ANTIALIAS` on older Pillows.
Fixes issue #49.

If you want to try it out, you can edit `sources-60.ini` and add:

```
version-overrides =
    Pillow==9.1.0
```

I will update the pin in coredev after merge of this PR.
