### PR TITLE
Fix CI: libvcs 0.12 fails for us.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,11 @@ commands =
 commands_pre =
     pip install mxdev
     mxdev -c sources-52.ini
-    pip install --use-deprecated legacy-resolver -rrequirements-52-mxdev.txt
+    pip install -rrequirements-52-mxdev.txt
 
 [testenv:plone60-py{37,38,39,310}]
 commands_pre =
     # for libvcs pin, see https://github.com/bluedynamics/mxdev/issues/10
     pip install mxdev "libvcs<0.12"
     mxdev -c sources-60.ini
-    pip install --use-deprecated legacy-resolver -rrequirements-60-mxdev.txt
+    pip install -rrequirements-60-mxdev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands_pre =
 
 [testenv:plone60-py{37,38,39,310}]
 commands_pre =
-    pip install mxdev
+    # for libvcs pin, see https://github.com/bluedynamics/mxdev/issues/10
+    pip install mxdev "libvcs<0.12"
     mxdev -c sources-60.ini
     pip install --use-deprecated legacy-resolver -rrequirements-60-mxdev.txt


### PR DESCRIPTION
Only pulled in on Python 3.9+.
See https://github.com/bluedynamics/mxdev/issues/10