### PR TITLE
Fix KeyErrors in ScalesDict conflict resolution

### DIFF
--- a/news/84.bugfix
+++ b/news/84.bugfix
@@ -1,0 +1,1 @@
+Fix KeyError in ScalesDict conflict resolution. @davisagli

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -104,7 +104,7 @@ class ScalesDict(PersistentDict):
                     del saved[key]
                 else:
                     # modified by saved, deleted by new
-                    self.raise_conflict(saved[key], new[key])
+                    self.raise_conflict(saved[key], key)
         for key in added:
             if key in saved:
                 # added by saved, added by new
@@ -116,7 +116,7 @@ class ScalesDict(PersistentDict):
         for key in modified:
             if key not in saved:
                 # deleted by saved, modified by new
-                self.raise_conflict(saved[key], new[key])
+                self.raise_conflict(key, new[key])
             elif saved[key]["modified"] != old[key]["modified"]:
                 # modified by saved, modified by new
                 self.raise_conflict(saved[key], new[key])


### PR DESCRIPTION
Fixes #83 

There are a couple cases in the ScalesDict conflict resolution code that can throw a KeyError. This was looking up the current value for debugging purposes, but there are 2 cases where the value is expected to not be there, so we can't look it up.