### PR TITLE
Fix incompatibility with Pillow 10.1+.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 

--- a/news/89.bugfix
+++ b/news/89.bugfix
@@ -1,0 +1,4 @@
+Fix incompatibility with Pillow 10.1+.
+Instead of setting ``image.mode``, we call ``image.convert``.
+This works in Pillow 9 and 10.
+[maurits]

--- a/plone/scale/scale.py
+++ b/plone/scale/scale.py
@@ -174,7 +174,7 @@ def scaleSingleFrame(
         if extrema.get("A") == (255, 255):
             # no alpha used, just change the mode, which causes the alpha band
             # to be dropped on save
-            image.mode = "RGB"
+            image = image.convert("RGB")
         else:
             # switch to PNG, which supports alpha
             format_ = "PNG"


### PR DESCRIPTION
Instead of setting ``image.mode``, we call ``image.convert``. This works in Pillow 9 and 10.
Fixes #89.
