### PR TITLE
Forces the scale uid to be the same, regardless of the scale parameter being passed

### DIFF
--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,0 +1,1 @@
+Forces the scale uid to be the same, regardless of the scale parameter being passed. @wesleybl

--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,1 +1,1 @@
-Forces the scale uid to be the same, regardless of the scale parameter being passed. @wesleybl
+If width and height are given, ignore the scale parameter when determining the unique id of a scale. @wesleybl

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -205,7 +205,11 @@ class AnnotationStorage(MutableMapping):
         dimension = parameters.get("width", parameters.get("scale"))
         if dimension is None:
             dimension = 0
-        if "scale" in parameters:
+        if (
+            "scale" in parameters
+            and parameters.get("width")
+            and parameters.get("height")
+        ):
             del parameters["scale"]
         key = self.hash(modified=self.modified_time, **parameters)
         hash_key = hashlib.md5(str(key).encode("utf-8")).hexdigest()

--- a/plone/scale/storage.py
+++ b/plone/scale/storage.py
@@ -201,11 +201,13 @@ class AnnotationStorage(MutableMapping):
     def hash_key(self, **parameters):
         if "modified" in parameters:
             del parameters["modified"]
-        key = self.hash(modified=self.modified_time, **parameters)
         fieldname = parameters.get("fieldname", "image")
         dimension = parameters.get("width", parameters.get("scale"))
         if dimension is None:
             dimension = 0
+        if "scale" in parameters:
+            del parameters["scale"]
+        key = self.hash(modified=self.modified_time, **parameters)
         hash_key = hashlib.md5(str(key).encode("utf-8")).hexdigest()
         # We return a uid that is recognizable when you inspect a url in html or
         # on the network tab: you immediately see for which field this is and what

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -217,6 +217,14 @@ class AnnotationStorageTests(TestCase):
         ]
         self.assertEqual(uid1, uid2)
 
+    def test_scale_without_height_width(self):
+        # Ensures that the scale will only be removed from the hash key
+        # if we have width and height.
+        self._provide_dummy_scale_adapter()
+        storage = self.storage
+        uid = storage.scale(fieldname="image", scale="icon")["uid"]
+        self.assertEqual(uid, "image-icon-b6e2a135d96703b73688a0d91f741a65")
+
     def testGetItem(self):
         self._provide_dummy_scale_adapter()
         storage = self.storage

--- a/plone/scale/tests/test_storage.py
+++ b/plone/scale/tests/test_storage.py
@@ -199,6 +199,24 @@ class AnnotationStorageTests(TestCase):
         scale2 = storage.scale(bar=42, foo=23, hurz="!")
         self.assertIsNot(scale1, scale2)
 
+    def test_pre_scale_with_and_without_scale_same_uid(self):
+        self._provide_dummy_scale_adapter()
+        storage = self.storage
+        uid1 = storage.pre_scale(fieldname="image", height=32, width=32)["uid"]
+        uid2 = storage.pre_scale(fieldname="image", height=32, width=32, scale="icon")[
+            "uid"
+        ]
+        self.assertEqual(uid1, uid2)
+
+    def test_scale_with_and_without_scale_same_uid(self):
+        self._provide_dummy_scale_adapter()
+        storage = self.storage
+        uid1 = storage.scale(fieldname="image", height=32, width=32)["uid"]
+        uid2 = storage.scale(fieldname="image", height=32, width=32, scale="icon")[
+            "uid"
+        ]
+        self.assertEqual(uid1, uid2)
+
     def testGetItem(self):
         self._provide_dummy_scale_adapter()
         storage = self.storage


### PR DESCRIPTION
For this to happen, we remove the `scale` parameter from the hash generation. This makes the scales in the catalog the same as those in the object views.

Fixes https://github.com/plone/Products.CMFPlone/issues/3850