### PR TITLE
Prevent deprecation warning for PersistentDict: use PersistentMapping.

### DIFF
--- a/news/+88885c50.bugfix.rst
+++ b/news/+88885c50.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent deprecation warning for ``PersistentDict``: use ``PersistentMapping``.  [maurits]

--- a/src/plone/scale/storage.py
+++ b/src/plone/scale/storage.py
@@ -1,7 +1,7 @@
 from .scale import calculate_scaled_dimensions
 from .scale import get_scale_mode
 from collections.abc import MutableMapping
-from persistent.dict import PersistentDict
+from persistent.mapping import PersistentMapping
 from plone.scale.interfaces import IImageScaleFactory
 from time import time
 from ZODB.POSException import ConflictError
@@ -71,7 +71,7 @@ class IImageScaleStorage(Interface):
         """
 
 
-class ScalesDict(PersistentDict):
+class ScalesDict(PersistentMapping):
     def raise_conflict(self, saved, new):
         logger.info("Conflict")
         logger.debug("saved\n" + pprint.pformat(saved))
@@ -179,7 +179,7 @@ class AnnotationStorage(MutableMapping):
                 safeWrite(self.context)
         scales = annotations["plone.scale"]
         if not isinstance(scales, ScalesDict):
-            # migrate from PersistentDict to ScalesDict
+            # migrate from PersistentMapping to ScalesDict
             new_scales = ScalesDict(scales)
             annotations["plone.scale"] = new_scales
             if safeWrite is not None:


### PR DESCRIPTION
`persistent/dict.py`  simply has this code, for a long time now:

```
from zope.deferredimport import deprecated

deprecated(
    "`persistent.dict.PersistentDict` is deprecated. Use"
    " `persistent.mapping.PersistentMapping` instead."
    " This backward compatibility shim will be removed in persistent"
    " version 7.",
    PersistentDict='persistent.mapping:PersistentMapping',
)
```

Originally this was supposed to be removed in version 6. And already since `persistent` 4.0.0 from 2012 is `PersistentDict` a backwards compatibility import for `PersistentMapping`.

So it seems safe to finally make the shift here. :-)
