### PR TITLE
Fix IndexError scaling images with non-RGB color modes

### DIFF
--- a/news/34.bugfix
+++ b/news/34.bugfix
@@ -1,0 +1,2 @@
+Fix ``IndexError`` when scaling images with non-RGB color modes (e.g. BMP with palette+alpha).
+@jensens

--- a/src/plone/scale/scale.py
+++ b/src/plone/scale/scale.py
@@ -185,12 +185,12 @@ def scaleSingleFrame(
 
     # convert to simpler mode if possible
     colors = image.getcolors(maxcolors=256)
-    if image.mode not in ("P", "L", "LA") and colors:
-        if format_ == "JPEG":
+    if colors:
+        if image.mode in ("RGB", "RGBA") and format_ == "JPEG":
             # check if it's all grey
             if all(rgb[0] == rgb[1] == rgb[2] for c, rgb in colors):
                 image = image.convert("L")
-        elif format_ in ("PNG", "GIF"):
+        elif image.mode not in ("P", "L", "LA") and format_ in ("PNG", "GIF"):
             image = image.convert("P")
 
     if image.mode == "RGBA" and format_ == "JPEG":

--- a/src/plone/scale/tests/test_scale.py
+++ b/src/plone/scale/tests/test_scale.py
@@ -146,6 +146,17 @@ class ScalingTests(TestCase):
         # Check format maintained
         self.assertEqual(scaled_image.format, "PNG")
 
+    def testScaleNonRGBColorTuples(self):
+        # Images in modes like LA (greyscale+alpha) return 2-element color
+        # tuples from getcolors(), not 3-element RGB tuples.  The greyscale
+        # optimisation must not crash with IndexError on these.
+        # See https://github.com/plone/plone.scale/issues/34
+        src = PIL.Image.new("LA", (100, 100), (128, 255))
+        buf = StringIO()
+        src.save(buf, "PNG")
+        imagedata, format_, size = scaleImage(buf.getvalue(), 50, 50, "scale")
+        self.assertIsNotNone(imagedata)
+
     def testAutomaticPalette(self):
         # get a JPEG with more than 256 colors
         jpeg = PIL.Image.open(StringIO(PROFILE))


### PR DESCRIPTION
## Summary

- The greyscale optimisation in `scaleSingleFrame` assumed `getcolors()` returns 3-element RGB tuples, but modes like PA (palette+alpha) and LA (greyscale+alpha) return 2-element tuples
- `rgb[2]` caused `IndexError` for BMP images with palette modes
- Fix: restrict the greyscale check to `image.mode in ("RGB", "RGBA")` instead of excluding specific modes with a denylist

## Test plan

- [x] New test `testScaleNonRGBColorTuples` with LA mode image
- [x] Existing `testAutomaticGreyscale` still passes (RGB grey detection works)
- [x] All 59 tests pass

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)