### PR TITLE
Fix incorrect scale calculation if zero-width.

### DIFF
--- a/news/140.bugfix.rst
+++ b/news/140.bugfix.rst
@@ -5,6 +5,10 @@ zero-dimension should be calculated by keeping the aspect ratio. This works
 fine when height is set to ``0`` but breaks and generates a ``1x1`` dimension
 if width is ``0``.
 
+Additionally, ``scale_svg_image`` raised ``ZeroDivisionError`` when either
+target dimension was ``0`` or ``None``. The SVG scaling path now applies the
+same "zero means auto, keep aspect ratio" semantics as the raster path.
+
 This PR fixes that.
 
 @thet

--- a/news/140.bugfix.rst
+++ b/news/140.bugfix.rst
@@ -2,7 +2,7 @@ Fix incorrect scale calculation if zero-width.
 
 When width or height are set to ``0`` and the other dimension is set, the
 zero-dimension should be calculated by keeping the aspect ratio. This works
-fine when height is set t o ``0`` but breaks and generates a ``1x1`` dimension
+fine when height is set to ``0`` but breaks and generates a ``1x1`` dimension
 if width is ``0``.
 
 This PR fixes that.

--- a/news/140.bugfix.rst
+++ b/news/140.bugfix.rst
@@ -1,0 +1,10 @@
+Fix incorrect scale calculation if zero-width.
+
+When width or height are set to ``0`` and the other dimension is set, the
+zero-dimension should be calculated by keeping the aspect ratio. This works
+fine when height is set t o ``0`` but breaks and generates a ``1x1`` dimension
+if width is ``0``.
+
+This PR fixes that.
+
+@thet

--- a/src/plone/scale/scale.py
+++ b/src/plone/scale/scale.py
@@ -267,6 +267,9 @@ def _calculate_all_dimensions(
     if height is not None and (height >= MAX_HEIGHT or height <= 0):
         height = None
 
+    if width is not None and width <= 0:
+        width = None
+
     if mode not in ("contain", "cover", "scale"):
         raise ValueError("Unknown scale mode '%s'" % mode)
 

--- a/src/plone/scale/scale.py
+++ b/src/plone/scale/scale.py
@@ -634,11 +634,32 @@ def scale_svg_image(
             f"Can not convert source dimensions: '{source_width}':'{source_height}'"
         )
         return etree.tostring(tree, encoding="utf-8", xml_declaration=True), (
-            int(target_width),
-            int(target_height),
+            int(target_width or 0),
+            int(target_height or 0),
         )
 
-    source_aspectratio = source_width / source_height
+    # Normalize target dimensions: 0 or None means "auto — derive from source
+    # aspect ratio". Same semantics as ``_calculate_all_dimensions`` uses for
+    # raster images.
+    if target_width is not None and target_width <= 0:
+        target_width = None
+    if target_height is not None and target_height <= 0:
+        target_height = None
+
+    if not source_width or not source_height:
+        # Cannot compute source aspect ratio; fall back to requested dims.
+        source_aspectratio = 1.0
+        target_width = target_width or int(source_width) or 1
+        target_height = target_height or int(source_height) or 1
+    else:
+        source_aspectratio = source_width / source_height
+        if target_width is None and target_height is None:
+            target_width, target_height = source_width, source_height
+        elif target_width is None:
+            target_width = target_height * source_aspectratio
+        elif target_height is None:
+            target_height = target_width / source_aspectratio
+
     target_aspectratio = target_width / target_height
     if mode in ["scale", "cover"]:
         # check if new width is larger than the one we get with aspect ratio

--- a/src/plone/scale/tests/test_scale.py
+++ b/src/plone/scale/tests/test_scale.py
@@ -539,6 +539,27 @@ class ScalingTests(TestCase):
         self.assertNotIn(b'width="100"', scaled_svg[0])
         self.assertNotIn(b'height="100"', scaled_svg[0])
 
+    def testScaleSVGImageZeroDimensions(self):
+        # logo.svg has aspect ratio 158.253 / 40.686 ~= 3.889
+        # Zero height -> derive from source aspect ratio (keeps aspect).
+        _, (w, h) = scale_svg_image(StringIO(SVG), 200, 0, mode="scale")
+        self.assertEqual(w, 200)
+        self.assertEqual(h, int(200 / (158.253 / 40.686)))
+
+        # Zero width -> derive from source aspect ratio.
+        _, (w, h) = scale_svg_image(StringIO(SVG), 0, 100, mode="scale")
+        self.assertEqual(h, 100)
+        self.assertEqual(w, int(100 * (158.253 / 40.686)))
+
+        # None height -> same as zero.
+        _, (w, h) = scale_svg_image(StringIO(SVG), 200, None, mode="scale")
+        self.assertEqual(w, 200)
+
+        # contain mode with zero height must not raise.
+        _, (w, h) = scale_svg_image(StringIO(SVG), 200, 0, mode="contain")
+        self.assertEqual(w, 200)
+        self.assertGreater(h, 0)
+
 
 def test_suite():
     from unittest import defaultTestLoader

--- a/src/plone/scale/tests/test_scale.py
+++ b/src/plone/scale/tests/test_scale.py
@@ -452,15 +452,23 @@ class ScalingTests(TestCase):
         """
         # calc = functools.partial(calculate_scaled_dimensions, mode="scale")
         calc = calculate_scaled_dimensions
+
         self.assertEqual(calc(1, 1, 1, 1), (1, 1))
         self.assertEqual(calc(10, 10, 1, 1), (1, 1))
+
         # Mode "scale" only scales down, not up:
         self.assertEqual(calc(1, 1, 10, 10), (1, 1))
         self.assertEqual(calc(10, 20, 10, 10), (5, 10))
+
         # Try the new preview scale:
         self.assertEqual(calc(10, 20, 400, 65536), (10, 20))
         self.assertEqual(calc(600, 300, 400, 65536), (400, 200))
         self.assertEqual(calc(600, 1200, 400, 65536), (400, 800))
+
+        # Scale with width `0`
+        self.assertEqual(calc(100, 100, 0, 50), (50, 50))
+        # Scale with height `0`
+        self.assertEqual(calc(100, 100, 50, 0), (50, 50))
 
     def testAnimatedGifContainsAllFrames(self):
         image = scaleImage(ANIGIF, 84, 103, "contain")[0]


### PR DESCRIPTION
When width or height are set to ``0`` and the other dimension is set, the zero-dimension should be calculated by keeping the aspect ratio. This works fine when height is set t o ``0`` but breaks and generates a ``1x1`` dimension if width is ``0``.

This PR fixes that.

## Note

This PR probably needs an upgrade step in plone.app.upgrade.

We encountered this problem with incorrect `1x1` dimensions in the catalog with the `image_scales` metadata column.

The plan would be to run through all `plone.namedfile.interfaces.IImageScaleTraversable` objects and adapting `plone.scale.storage.IImageScaleStorage` on each image object and calling `adapter.clear()` on it. That would remove the stored dimensions and with the next access it would be re-created.
I just wonder, if I should just call a `object.reindexObject(idxs=["image_scales"])` also, a potential expensive operation.

Any suggestions?

## Meta

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #140

