### PR TITLE
add `fieldname` to the scale information created by `pre_scale`

### DIFF
--- a/news/143.feature
+++ b/news/143.feature
@@ -1,0 +1,1 @@
+Add missing `fieldname` key to the scale information produced by `pre_scale` method @erral

--- a/src/plone/scale/storage.py
+++ b/src/plone/scale/storage.py
@@ -259,6 +259,7 @@ class AnnotationStorage(MutableMapping):
             data=None,
             width=width,
             height=height,
+            fieldname=fieldname,
         )
         self.storage[uid] = info
         logger.debug(f"Pre scale returns new {info}")

--- a/src/plone/scale/storage.py
+++ b/src/plone/scale/storage.py
@@ -259,8 +259,9 @@ class AnnotationStorage(MutableMapping):
             data=None,
             width=width,
             height=height,
-            fieldname=fieldname,
         )
+        if fieldname:
+            info["fieldname"] = fieldname
         self.storage[uid] = info
         logger.debug(f"Pre scale returns new {info}")
         return info

--- a/src/plone/scale/tests/test_storage.py
+++ b/src/plone/scale/tests/test_storage.py
@@ -76,6 +76,7 @@ class AnnotationStorageTests(TestCase):
         scale = storage.scale(foo=23, bar=42)
         self.assertIn("uid", scale)
         self.assertIn("key", scale)
+        self.assertIn("fieldname", scale)
         self.assertEqual(scale["data"], "some data")
         self.assertEqual(scale["width"], 42)
 
@@ -96,6 +97,7 @@ class AnnotationStorageTests(TestCase):
         scale = storage.pre_scale(foo=23, bar=42)
         self.assertIn("uid", scale)
         self.assertIn("key", scale)
+        self.assertIn("fieldname", scale)
         self.assertEqual(scale["data"], None)
         # We get the values from the DummyImage class.
         self.assertEqual(scale["width"], 60)

--- a/src/plone/scale/tests/test_storage.py
+++ b/src/plone/scale/tests/test_storage.py
@@ -76,7 +76,6 @@ class AnnotationStorageTests(TestCase):
         scale = storage.scale(foo=23, bar=42)
         self.assertIn("uid", scale)
         self.assertIn("key", scale)
-        self.assertIn("fieldname", scale)
         self.assertEqual(scale["data"], "some data")
         self.assertEqual(scale["width"], 42)
 
@@ -97,12 +96,18 @@ class AnnotationStorageTests(TestCase):
         scale = storage.pre_scale(foo=23, bar=42)
         self.assertIn("uid", scale)
         self.assertIn("key", scale)
-        self.assertIn("fieldname", scale)
         self.assertEqual(scale["data"], None)
         # We get the values from the DummyImage class.
         self.assertEqual(scale["width"], 60)
         self.assertEqual(scale["height"], 40)
         self.assertEqual(scale["mimetype"], "image/jpeg")
+
+    def testScaleWithFieldname(self):
+        self._provide_dummy_scale_adapter()
+        storage = self.storage
+        scale = storage.scale(foo=23, bar=42, fieldname="image")
+        self.assertIn("fieldname", scale)
+        self.assertEqual(scale["fieldname"], "image")
 
     def testPreScaleForNonExistingScale(self):
         self._provide_dummy_scale_adapter()
@@ -148,6 +153,13 @@ class AnnotationStorageTests(TestCase):
         # scale does the same.
         new_scale = storage.scale(width=50, height=80)
         self.assertIsNone(new_scale)
+
+    def testPreScaleWithFieldname(self):
+        self._provide_dummy_scale_adapter()
+        storage = self.storage
+        scale = storage.pre_scale(foo=23, bar=42, fieldname="image")
+        self.assertIn("fieldname", scale)
+        self.assertEqual(scale["fieldname"], "image")
 
     def test_get_or_generate(self):
         self._provide_dummy_scale_adapter()


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

When creating a scale using `scale` we delegate to `generate_scale` which [adds the `fieldname` key to the scale if it is available](https://github.com/plone/plone.scale/blob/master/src/plone/scale/storage.py#L294-L295)

But [`pre_scale` doesn't do it](https://github.com/plone/plone.scale/blob/master/src/plone/scale/storage.py#L254-L262) and the scale information lacks the `fieldname` key.

This means that methods calling `pre_scale` from `plone.namedfile` (like `srcset` for instance) do not get that key in the result, and then if the site is using [plone-pgthumbor](https://github.com/bluedynamics/plone-pgthumbor/blob/main/src/plone/pgthumbor/scaling.py#L212) can't create Thumbor based URLs.

That's the only use-case I have found where the `fieldname` key is missing in the scale information, but there may be others, because I am myself using `srcset` method in `plone.namedfile`.
